### PR TITLE
Add class hidden to separator

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -353,7 +353,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                         </button>
 
 <!--#if !GENERIC-->
-<!--            <div class="horizontalToolbarSeparator"></div>-->
+           <div class="horizontalToolbarSeparator hidden"></div>
 <!--#endif-->
                       </div>
 


### PR DESCRIPTION
Use class `hidden` instead of commenting separator.