### PR TITLE
Remove CORS validation check from pdfjs side

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -683,7 +683,7 @@ const PDFViewerApplication = {
       const queryString = document.location.search.substring(1);
       const params = parseQueryString(queryString);
       file = params.get("file") ?? AppOptions.get("defaultUrl");
-      validateFileURL(file);
+      // validateFileURL(file);
     } else if (PDFJSDev.test("MOZCENTRAL")) {
       file = window.location.href;
     } else if (PDFJSDev.test("CHROME")) {
@@ -2215,36 +2215,35 @@ if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
 }
 
 if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-  const HOSTED_VIEWER_ORIGINS = [
-    "null",
-    "http://mozilla.github.io",
-    "https://mozilla.github.io",
-  ];
-  // eslint-disable-next-line no-var
-  var validateFileURL = function (file) {
-    if (!file) {
-      return;
-    }
-    try {
-      const viewerOrigin = new URL(window.location.href).origin || "null";
-      if (HOSTED_VIEWER_ORIGINS.includes(viewerOrigin)) {
-        // Hosted or local viewer, allow for any file locations
-        return;
-      }
-      const fileOrigin = new URL(file, window.location.href).origin;
-      // Removing of the following line will not guarantee that the viewer will
-      // start accepting URLs from foreign origin -- CORS headers on the remote
-      // server must be properly configured.
-      if (fileOrigin !== viewerOrigin) {
-        throw new Error("file origin does not match viewer's");
-      }
-    } catch (ex) {
-      PDFViewerApplication._documentError("pdfjs-loading-error", {
-        message: ex.message,
-      });
-      throw ex;
-    }
-  };
+  // const HOSTED_VIEWER_ORIGINS = [
+  //   "null",
+  //   "http://mozilla.github.io",
+  //   "https://mozilla.github.io",
+  // ];
+  // var validateFileURL = function (file) {
+  //   if (!file) {
+  //     return;
+  //   }
+  //   try {
+  //     const viewerOrigin = new URL(window.location.href).origin || "null";
+  //     if (HOSTED_VIEWER_ORIGINS.includes(viewerOrigin)) {
+  //       // Hosted or local viewer, allow for any file locations
+  //       return;
+  //     }
+  //    const fileOrigin = new URL(file, window.location.href).origin;
+  //    Removing of the following line will not guarantee that the viewer will
+  //    start accepting URLs from foreign origin -- CORS headers on the remote
+  //    server must be properly configured.
+  //    if (fileOrigin !== viewerOrigin) {
+  //      throw new Error("file origin does not match viewer's");
+  //    }
+  //  } catch (ex) {
+  //    PDFViewerApplication._documentError("pdfjs-loading-error", {
+  //      message: ex.message,
+  //    });
+  //    throw ex;
+  //  }
+  // };
 
   // eslint-disable-next-line no-var
   var onFileInputChange = function (evt) {


### PR DESCRIPTION
+ We need to remove CORS policy check on pdfjs, otherwise we cannot display the pdfs from SharinPix.
+ The CORS policy should instead be handled in the amazon bucket.