### PR TITLE
Hide separator in menu

### DIFF
--- a/web/viewer.html
+++ b/web/viewer.html
@@ -358,7 +358,7 @@ See https://github.com/adobe-type-tools/cmap-resources
                       </div>
 
 <!--#if GENERIC-->
-                      <div class="horizontalToolbarSeparator"></div>
+                      <div class="horizontalToolbarSeparator hidden"></div>
 <!--#endif-->
 
                       <button id="presentationMode" class="toolbarButton labeled" type="button" title="Switch to Presentation Mode" tabindex="0" data-l10n-id="pdfjs-presentation-mode-button">


### PR DESCRIPTION
Hide extra separator at the top of the menu.