### PR TITLE
Remove console.error

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -248,7 +248,8 @@ function webViewerLoad() {
     } catch (ex) {
       // The viewer could be in e.g. a cross-origin <iframe> element,
       // fallback to dispatching the event at the current `document`.
-      console.error(`webviewerloaded: ${ex}`);
+      // console.error(`webviewerloaded: ${ex}`);
+      console.log("Dispatching event on current document due to cross-origin restriction: ", ex);
       document.dispatchEvent(event);
     }
   }

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -249,7 +249,10 @@ function webViewerLoad() {
       // The viewer could be in e.g. a cross-origin <iframe> element,
       // fallback to dispatching the event at the current `document`.
       // console.error(`webviewerloaded: ${ex}`);
-      console.log("Dispatching event on current document due to cross-origin restriction: ", ex);
+      console.log(
+        "Dispatching event on current document due to cross-origin restriction: ",
+        ex
+      );
       document.dispatchEvent(event);
     }
   }


### PR DESCRIPTION
+ Replacing `console.error` with `console.log` since we use PDFJS in iframe on core and getting unecessary error in console.